### PR TITLE
Alteração/correção dos títulos e subtítulos dos Markdown

### DIFF
--- a/Apostila/conditions.md
+++ b/Apostila/conditions.md
@@ -1,4 +1,4 @@
-#Condições
+# Condições
 
 
 As diretivas de controle do Sass permitem a utilização de operadores condicionais e iterações. Neste capítulo serão explicadas as diretivas condicionais @if e @else.

--- a/Apostila/functions.md
+++ b/Apostila/functions.md
@@ -1,8 +1,8 @@
-#Funções
+# Funções
 
 O Sass possui algumas funções nativas e também possibilita que sejam criadas novas funções.
 
-##Criando uma função
+## Criando uma função
 
 A declaração de uma função começa com @function, em seguida vem o nome da função, que pode conter qualquer combinação de caracteres alfabéticos e numéricos sem espaços, os argumentos entre parênteses e a definição da função entre chaves.
 
@@ -14,7 +14,7 @@ As funções podem acessar quaisquer variáveis definidas globalmente. Uma funç
 }
 ```
 
-##Utilizando uma função
+## Utilizando uma função
 
 Para utilizar uma função basta colocar o nome e passar os argumentos:
 
@@ -32,11 +32,11 @@ div {
 }
 ```
 
-##Funções Nativas
+## Funções Nativas
 
 Nesta apostila serão mostradas algumas das principais funções nativas do Sass. É possível consultar uma lista com todas as funções nativas no site do <a href="http://sass-lang.com/documentation/Sass/Script/Functions.html" target="_blank">Sass</a>.
 
-###Funções de cor
+### Funções de cor
 
 - rgb($red, $green, $blue)
 Retorna uma cor de acordo com os valores passados para o vermelho, verde e azul.
@@ -50,7 +50,7 @@ Retorna a cor mais clara de acordo com a cor e porcentagem de claridade passada 
 - darken($color, $amount)
 Escurece a cor de acordo porcentagem passada como argumento.
 
-###Funções com strings
+### Funções com strings
 
 - unquote($string)
 Remove as aspas de uma string
@@ -67,7 +67,7 @@ Retorna a string em letras maiúsculas
 - to-lower-case($string)
 Retorna a string em letras minúsculas
 
-###Funções com números
+### Funções com números
 
 - percentage($number)
 Converte um número sem unidade a uma percentagem
@@ -81,7 +81,7 @@ Arredonda um número até o próximo número inteiro
 - floor($number)
 Arredonda um número para baixo para o número inteiro anterior
 
-###Funções com listas
+### Funções com listas
 
 - length($list)
 Retorna a quantidade de itens de uma lista
@@ -95,7 +95,7 @@ Junta duas listas em uma
 - append($list1, $val, [$separator])
 Acrescenta um valor único no fim da lista
 
-###Funções com maps
+### Funções com maps
 
 - map-merge($map1, $map2)
 Une dois maps em um só map

--- a/Apostila/import.md
+++ b/Apostila/import.md
@@ -1,4 +1,4 @@
-#@import
+# @import
 
 Através da diretiva @import é possível importar arquivos no seu arquivo principal. Durante o processo de compilação os arquivos importados são unificados gerando um único arquivo CSS. Todas as variáveis ou mixins definidas nos arquivos importados podem ser usados no arquivo principal.
 
@@ -32,7 +32,7 @@ Exemplos de utilização
 @import "file1", "file2";
 ```
 
-##Partials
+## Partials
 
 Para organizar melhor o seu projeto, utilizando o import você pode dividir seu CSS em vários pedaços e importar em um arquivo principal. Caso você deseje importar cada arquivo scss/sass de estilo específico, mas não quer que toda hora esse arquivo seja compilado para um arquivo separado, basta colocar um _ na frente do nome do arquivo. Isto indicará para o Sass não compilá-lo para um arquivo CSS, este é o conceito de **partials**. 
 

--- a/Apostila/iteration.md
+++ b/Apostila/iteration.md
@@ -1,8 +1,8 @@
-#Iterações
+# Iterações
 
 Para realização de iterações, existem as diretivas @for, @each e @while.
 
-##@for
+## @for
 
 A diretiva @for pode ser utilizada de duas formas:
 
@@ -59,7 +59,7 @@ Será compilado para:
 }
 ```
 
-##@each
+## @each
 
 A diretiva @each trabalha com [listas](https://github.com/Webschool-io/Curso-CSS-SASS/blob/master/Apostila/variables.md#lista).
 
@@ -103,7 +103,7 @@ Será compilado para:
 
 ```
 
-##@while
+## @while
 
 A diretiva @while recebe uma expressão e imprime um o bloco de estilos até que a expressão seja falsa. Esta diretiva é muito parecida com a diretiva @for, é possível criar instruções de loop muito complexos "enquanto" uma condição específica é avaliada como verdadeira.
 

--- a/Apostila/media-queries.md
+++ b/Apostila/media-queries.md
@@ -1,4 +1,4 @@
-#@media
+# @media
 
 A diretiva @media funciona no Sass da mesma forma que funciona no CSS, porém há possibilidade de encaixá-las em regras CSS, desta forma é possível declarar dentro do seletor qual será o comportamento dele de acordo com cada @media.
 
@@ -45,7 +45,7 @@ A @media é declarada para cada seletor. No momento de compilação todas as reg
 }
 
 ```
-###mixins + media + interpolation + @content
+### mixins + media + interpolation + @content
 
 A seguir será apresentado um exemplo utilizando mixins, media, interpolação e content, cujo objetivo é simplificar a chamada das diferentes diretivas @media que podem existir em seu CSS.
 

--- a/Apostila/mixins.md
+++ b/Apostila/mixins.md
@@ -1,9 +1,9 @@
-#Mixins
+# Mixins
 
 A diretiva @mixin permite definir estilos que podem ser reutilizados em toda a folha de estilo. Os mixins funcionam como uma função que retorna CSS em vez de um único valor.
 Muitas vezes temos declarações repetidas várias vezes no arquivo CSS, para corrigir isso, pode-se criar um mixin.
 
-##Como declarar
+## Como declarar
 
 A declaração do mixin começa com @mixin, em seguida vem o nome do mixin, que pode conter qualquer combinação de caracteres alfabéticos e numéricos sem espaços e os argumentos entre parênteses. O mixin border-radius utilizado como exemplo, só possui um argumento $radius, mas pode-se utilizar vários argumentos desde que eles estejam separados por vírgulas. Por fim, entre chaves vem a definição do mixin que conter qualquer combinação de atributos CSS.
 
@@ -19,7 +19,7 @@ A declaração do mixin começa com @mixin, em seguida vem o nome do mixin, que 
 
 Com este mixin criado, não será mais necessário repetir as 4 linhas de código utilizadas para que o border-radius funcione em todos os navegadores.
 
-##Como utilizar
+## Como utilizar
 
 Para utilizar o mixin, basta utilizar a palavra @include, o nome do mixin e os argumentos na ordem utilizada na declaração.
 
@@ -42,7 +42,7 @@ Será compilado para:
 }
 ```
 
-##Default Arguments
+## Default Arguments
 
 Na criação do mixin é possível especificar valores padrão para os argumentos, caso o argumento seja passado um argumento diferente o argumento será utilizado, caso contrário o valor padrão será utilizado.
 
@@ -77,7 +77,7 @@ h1 {
 }
 ```
 
-##Keyword Arguments
+## Keyword Arguments
 
 Keyword Arguments existem a partir Sass 3.1, com os Keyword Arguments, os argumentos ficam explícitos na chamada do mixin e é possível utilizar os argumentos em qualquer ordem.
 
@@ -106,7 +106,7 @@ h1 {
 
 Embora fique redundante, esta forma pode facilitar a leitura dos mixins, o que é importante para ter um código de fácil manutenção.
 
-##Variable arguments
+## Variable arguments
 
 Às vezes é necessário criar um mixin mais flexível, por exemplo, o padding por exemplos pode ter de um a quatro argumentos. Neste caso pode-se criar um mixin de argumentos variáveis, desta forma os argumentos são empacotados como uma lista.
 

--- a/Apostila/placeholders.md
+++ b/Apostila/placeholders.md
@@ -1,4 +1,4 @@
-#Placeholders
+# Placeholders
 
 A declaração de placeholders é semelhante a de classes e ids, o # ou . são substituídos por %, a grosso modo pode-se dizer que placeholders são classes que não aparecem no CSS compilado.
 


### PR DESCRIPTION
Olá Amanda, tudo bem?
Estou fazendo seu curso de Sass no YouTube e olhando o material no Github percebi que alguns títulos e subtítulos não estavam de acordo com o indicado na formatação do MD. Então resolvi fazer a alteração para corrigir esse detalhe e facilitar a leitura do conteúdo.

Parabéns pelo curso, você tem uma excelente didática!! 